### PR TITLE
⚡ Bolt: Memoize DesktopGrid in ImageSlider to prevent unnecessary re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,8 @@
 
 **Learning:** Client-side CSV fetching and parsing (`fetch` + `papaparse` in `useEffect`) delays content rendering and blocks main thread.
 **Action:** Move CSV reading and parsing to Server Components using `fs` (for files in `public/`) and pass data as props to Client Components.
+
+## 2024-06-25 - Prevent Unnecessary Re-renders on Mobile Sliders
+
+**Learning:** Components containing both static views (e.g. `DesktopGrid`) and interactive views (e.g. `MobileSlider` driven by `currentIndex` state) can suffer from unnecessary re-renders of the static portions when state changes.
+**Action:** Wrap the static sub-components (like `DesktopGrid`) with `React.memo` to optimize performance, preventing expensive re-renders when local state changes only affect the interactive sub-components.

--- a/src/components/ImageSlider.tsx
+++ b/src/components/ImageSlider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, memo } from "react";
 import StrainImage from "./StrainImage";
 
 interface ImageSliderProps {
@@ -128,7 +128,9 @@ function MobileSlider({
 }
 
 // Desktop Grid Component - Show all images in a responsive grid
-function DesktopGrid({ images }: ImageSliderProps) {
+// ⚡ Bolt: Memoized DesktopGrid to prevent unnecessary re-renders when the parent
+// ImageSlider's currentIndex changes (which only affects the mobile view).
+const DesktopGrid = memo(function DesktopGrid({ images }: ImageSliderProps) {
   return (
     <div className="w-full grid grid-cols-1 md:grid-cols-3 gap-4">
       {images.map((image, index) => (
@@ -144,7 +146,7 @@ function DesktopGrid({ images }: ImageSliderProps) {
       ))}
     </div>
   );
-}
+});
 
 export default function ImageSlider({
   images,


### PR DESCRIPTION
💡 What:
Wrapped the `DesktopGrid` function component in `React.memo` inside `src/components/ImageSlider.tsx` and added an explanatory comment.

🎯 Why:
The `ImageSlider` component manages a `currentIndex` state to support the `MobileSlider` interactions (like swiping or clicking dots). However, updating `currentIndex` previously caused a re-render of the entire `ImageSlider`, including the `DesktopGrid` component. Since `DesktopGrid` only relies on the static `images` prop and does not depend on `currentIndex`, re-rendering it is unnecessary and computationally expensive, especially since it renders a grid of potentially several high-resolution images.

📊 Impact:
Reduces re-renders by 100% for the `DesktopGrid` component when interacting with the mobile slider. The `DesktopGrid` will now only re-render if its `images` prop changes, improving the overall responsiveness and CPU utilization when users interact with the image slider on smaller screens.

🔬 Measurement:
To verify the improvement, you can use the React DevTools Profiler to record interactions with the image slider (e.g., swiping or clicking navigation dots). Before this change, the `DesktopGrid` component would be marked as rendered in the profiler; after this change, it should be greyed out (memoized) and not re-rendered during these interactions.

---
*PR created automatically by Jules for task [15108359325494228103](https://jules.google.com/task/15108359325494228103) started by @gokaiorg*