### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS in GardensList JSON-LD rendering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -74,3 +74,11 @@
 1. Systematically identified all components rendering links from data sources.
 2. Applied `sanitizeUrl` to all dynamic `href` and `src` attributes in these components.
 3. Reinforced the rule: "Any external data going into a URL attribute must be sanitized."
+
+## 2033-04-18 - GardensList JSON-LD Stored XSS
+
+**Vulnerability:** The `GardensList` component rendered JSON-LD structured data directly by stringifying it with `JSON.stringify` and inserting it into `dangerouslySetInnerHTML`. Because data points like `description` or `headline` come from a BigQuery database, an attacker could potentially execute a Stored XSS attack if they manage to insert malicious scripts (e.g. `</script><script>alert(1)</script>`) into the data source.
+**Learning:** `JSON.stringify` does not escape characters like `<` or `>`, which is necessary when inserting JSON inside a `<script>` tag via `dangerouslySetInnerHTML`. Always use a safe JSON-LD serialization utility like the built-in `toJsonLd` when inserting dynamic data into script tags.
+**Prevention:**
+1. Avoid `JSON.stringify` inside `dangerouslySetInnerHTML`.
+2. Use the provided `toJsonLd` utility helper function which properly escapes `<` to `\u003c`.

--- a/src/components/GardensList.tsx
+++ b/src/components/GardensList.tsx
@@ -1,3 +1,4 @@
+import { toJsonLd } from "@/lib/utils/json-ld";
 import Image from "next/image";
 import { getGardensData } from "@/lib/bigquery";
 
@@ -54,7 +55,7 @@ export default async function GardensList() {
     <div className="w-full max-w-4xl mx-auto py-12 px-4">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: toJsonLd(jsonLd) }}
       />
       <ul
         aria-label="Garden Updates Timeline"


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Stored XSS vulnerability in GardensList

🚨 Severity: HIGH
💡 Vulnerability: The `GardensList` component used `JSON.stringify(jsonLd)` inside `dangerouslySetInnerHTML` for rendering an `application/ld+json` script. This created a Stored XSS risk because external untrusted content coming from the data source (BigQuery) could contain tags (like `</script><script>alert(1)</script>`) that execute on the page.
🎯 Impact: High. Since `JSON.stringify` does not escape HTML characters, this allows an attacker that compromises the data source to inject harmful JavaScript across visitors.
🔧 Fix: Replaced `JSON.stringify` with the application's built-in `toJsonLd` function, which replaces `<` with `\u003c`, stopping the exploit from breaking out of the script tag.
✅ Verification: Ran `pnpm lint` and `pnpm build` successfully. The `dangerouslySetInnerHTML` call correctly references the sanitized string. Also created a Sentinel journal entry documenting the issue.

---
*PR created automatically by Jules for task [6108128585610177250](https://jules.google.com/task/6108128585610177250) started by @gokaiorg*