### PR TITLE
⚡ Bolt: Optimize parallax scroll event listeners to prevent unnecessary re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,7 @@
 
 **Learning:** Components containing both static views (e.g. `DesktopGrid`) and interactive views (e.g. `MobileSlider` driven by `currentIndex` state) can suffer from unnecessary re-renders of the static portions when state changes.
 **Action:** Wrap the static sub-components (like `DesktopGrid`) with `React.memo` to optimize performance, preventing expensive re-renders when local state changes only affect the interactive sub-components.
+## 2025-05-23 - Scroll Event Optimization via DOM Manipulation
+
+**Learning:** Using React state (`useState`) to track scroll position (`offsetY`) for UI effects (e.g. parallax or fixed positioning) causes excessive main-thread blocking re-renders during scroll events, drastically reducing scroll performance and smoothness.
+**Action:** When implementing scroll-based UI effects (like parallax image backgrounds), remove the React state. Instead, use a `useRef` to target the DOM element directly, and update its inline style within a `requestAnimationFrame` loop wrapped in a `window.addEventListener('scroll')` callback.

--- a/src/components/BannerMenu.tsx
+++ b/src/components/BannerMenu.tsx
@@ -12,9 +12,8 @@ export default function BannerMenu({
   imageSrc,
   alt = "Green Ghost Menu Banner",
 }: BannerMenuProps) {
-  const [offsetY, setOffsetY] = useState(0);
   const [isMobile, setIsMobile] = useState(false);
-  const ticking = useRef(false);
+  const imageContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     // Check if mobile on mount and resize
@@ -24,18 +23,26 @@ export default function BannerMenu({
 
     checkMobile();
 
+    let ticking = false;
     const onScroll = () => {
-      if (!ticking.current && window.innerWidth >= 768) {
+      if (!ticking && window.innerWidth >= 768) {
         window.requestAnimationFrame(() => {
-          setOffsetY(window.pageYOffset);
-          ticking.current = false;
+          if (imageContainerRef.current) {
+            const img = imageContainerRef.current.querySelector('img.object-cover') as HTMLImageElement;
+            if (img) {
+              img.style.objectPosition = `50% ${-window.pageYOffset * 0.1}px`;
+            }
+          }
+          ticking = false;
         });
-        ticking.current = true;
+        ticking = true;
       }
     };
 
-    window.addEventListener("scroll", onScroll);
+    window.addEventListener("scroll", onScroll, { passive: true });
     window.addEventListener("resize", checkMobile);
+    // Initial calculation
+    onScroll();
 
     return () => {
       window.removeEventListener("scroll", onScroll);
@@ -44,7 +51,7 @@ export default function BannerMenu({
   }, []);
 
   return (
-    <div className="relative w-full h-[250px] md:h-[450px] overflow-hidden mt-8 md:mt-12">
+    <div ref={imageContainerRef} className="relative w-full h-[250px] md:h-[450px] overflow-hidden mt-8 md:mt-12">
       <Image
         src={imageSrc}
         alt={alt}
@@ -53,7 +60,7 @@ export default function BannerMenu({
         fetchPriority="high"
         className="object-cover"
         style={{
-          objectPosition: isMobile ? "50% 0" : `50% ${-offsetY * 0.1}px`,
+          objectPosition: isMobile ? "50% 0" : "50% 0px", // Initial state
         }}
         sizes="100vw"
       />

--- a/src/components/PagesBannerClient.tsx
+++ b/src/components/PagesBannerClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useRef } from "react";
 import Image from "next/image";
 
 export interface PagesBannerClientProps {
@@ -18,16 +18,36 @@ export default function PagesBannerClient({
   iconSrc,
   iconAlt,
 }: PagesBannerClientProps) {
-  const [offsetY, setOffsetY] = useState(0);
-  const handleScroll = () => setOffsetY(window.pageYOffset);
+  const imageContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    window.addEventListener("scroll", handleScroll);
+    let ticking = false;
+    const handleScroll = () => {
+      if (!ticking) {
+        window.requestAnimationFrame(() => {
+          if (imageContainerRef.current) {
+            // Target the next/image img element which is a direct child usually,
+            // or we can query for the specific class.
+            const img = imageContainerRef.current.querySelector('img.object-cover.z-0') as HTMLImageElement;
+            if (img) {
+              img.style.objectPosition = `center ${window.pageYOffset * 0.5}px`;
+            }
+          }
+          ticking = false;
+        });
+        ticking = true;
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    // Initial position
+    handleScroll();
+
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
   return (
-    <div className="relative sm:min-h-[250px] md:min-h-[400px] flex flex-col items-center justify-center text-white md:p-8 mb-4 md:mb-8 overflow-hidden">
+    <div ref={imageContainerRef} className="relative sm:min-h-[250px] md:min-h-[400px] flex flex-col items-center justify-center text-white md:p-8 mb-4 md:mb-8 overflow-hidden">
       <Image
         src={`/images/banners/${bgSrc}`}
         alt={iconAlt || title}
@@ -38,7 +58,7 @@ export default function PagesBannerClient({
         loading="eager"
         className="object-cover z-0"
         style={{
-          objectPosition: `center ${offsetY * 0.5}px`,
+          objectPosition: "center 0px", // Initial state
         }}
       />
 


### PR DESCRIPTION
💡 **What:** Refactored `PagesBannerClient.tsx` and `BannerMenu.tsx` to remove `useState` tracking for scroll position (`offsetY`). Instead, used `useRef` and `requestAnimationFrame` to directly update the inline `objectPosition` styles of the target images within `{ passive: true }` scroll event listeners.

🎯 **Why:** Updating React state on every scroll tick causes the component to constantly re-render, blocking the main thread and leading to janky scrolling performance, especially on mobile or slower devices. By bypassing the React render cycle and using direct DOM manipulation, the parallax effect remains perfectly smooth.

📊 **Impact:** Reduces React re-renders for these components from hundreds per scroll down to effectively 0. Drastically improves scrolling frame rate and smoothness on pages utilizing these banners.

🔬 **Measurement:** Scroll on any page utilizing the `PagesBannerClient` or `BannerMenu` (e.g., location pages or the menu page) using Chrome DevTools Performance tab. You will notice a significant drop in JS execution time and a smoother frame rate during the scroll event compared to the baseline. Verify that the parallax visual effect still functions identically.

---
*PR created automatically by Jules for task [133182294099172923](https://jules.google.com/task/133182294099172923) started by @gokaiorg*