### PR TITLE
🎨 Palette: Improve Language Switcher Accessibility and Keyboard UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,6 @@
 
 **Learning:** The `MiniSlider` component is frequently nested within `Link` components (e.g., in product lists), creating invalid HTML and accessibility issues because it renders interactive `<button>` elements for slide indicators.
 **Action:** When using `MiniSlider` inside a `Link`, always pass `interactive={false}` to render the indicators as non-interactive `<span>` elements, preventing nested interactive controls while maintaining visual feedback.
+## 2024-11-20 - Custom Dropdown Accessibility Pattern
+**Learning:** Custom dropdown components built without primitives (like Radix UI) often miss crucial ARIA states (`aria-expanded`, `aria-haspopup`, `aria-controls`), roles (`menu`, `menuitem`), and keyboard events (closing on `Escape` key).
+**Action:** When inspecting or building custom menus/dropdowns, always ensure they include proper ARIA roles for the menu/items, explicit `focus-visible` styles for the interactive elements inside, and global keyboard event listeners to allow closing via the Escape key to satisfy basic WCAG requirements.

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -23,6 +23,7 @@ export default function LanguageSwitcher() {
   const [isOpen, setIsOpen] = useState(false);
   const { showLoader } = useLoader();
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   // Determine current language from URL
   const currentLangCode = pathname.startsWith("/fr") ? "fr" : "en";
@@ -42,6 +43,7 @@ export default function LanguageSwitcher() {
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape" && isOpen) {
         setIsOpen(false);
+        triggerRef.current?.focus();
       }
     }
 
@@ -55,6 +57,7 @@ export default function LanguageSwitcher() {
 
   const handleLanguageChange = (langCode: string) => {
     setIsOpen(false);
+    triggerRef.current?.focus();
     showLoader();
 
     // Logic to switch language while preserving path
@@ -85,6 +88,7 @@ export default function LanguageSwitcher() {
   return (
     <div className="relative" ref={dropdownRef}>
       <button
+        ref={triggerRef}
         onClick={() => setIsOpen(!isOpen)}
         className="flex items-center justify-center p-2 hover:bg-white/10 transition-colors text-white hover:text-[#13DE00] cursor-pointer focus-visible:ring-2 focus-visible:ring-[#13DE00] focus-visible:outline-none"
         aria-label="Select language"

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -38,9 +38,20 @@ export default function LanguageSwitcher() {
         setIsOpen(false);
       }
     }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape" && isOpen) {
+        setIsOpen(false);
+      }
+    }
+
     document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
 
   const handleLanguageChange = (langCode: string) => {
     setIsOpen(false);
@@ -75,21 +86,24 @@ export default function LanguageSwitcher() {
     <div className="relative" ref={dropdownRef}>
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center justify-center p-2 hover:bg-white/10 transition-colors text-white hover:text-[#13DE00] cursor-pointer"
+        className="flex items-center justify-center p-2 hover:bg-white/10 transition-colors text-white hover:text-[#13DE00] cursor-pointer focus-visible:ring-2 focus-visible:ring-[#13DE00] focus-visible:outline-none"
         aria-label="Select language"
         aria-expanded={isOpen}
+        aria-haspopup="true"
+        aria-controls="language-menu"
       >
         <Globe size={20} />
       </button>
 
       {isOpen && (
         <div className="absolute right-0 mt-2 w-32 bg-black border border-[#13DE00] shadow-lg overflow-hidden z-50 animate-in fade-in zoom-in-95 duration-200">
-          <ul className="py-1">
+          <ul id="language-menu" role="menu" className="py-1">
             {languages.map((lang) => (
-              <li key={lang.code}>
+              <li key={lang.code} role="none">
                 <button
+                  role="menuitem"
                   onClick={() => handleLanguageChange(lang.code)}
-                  className={`w-full text-left px-4 py-2 text-xs font-medium flex items-center space-x-2 hover:bg-[#13DE00]/20 transition-colors cursor-pointer
+                  className={`w-full text-left px-4 py-2 text-xs font-medium flex items-center space-x-2 hover:bg-[#13DE00]/20 transition-colors cursor-pointer focus-visible:bg-[#13DE00]/20 focus-visible:text-[#13DE00] focus-visible:outline-none
                     ${currentLang.code === lang.code ? "text-[#13DE00] bg-[#13DE00]/10" : "text-white"}
                   `}
                 >


### PR DESCRIPTION
💡 **What:** Improved the accessibility of the `LanguageSwitcher` custom dropdown component.
🎯 **Why:** Custom dropdowns built without primitives often miss crucial ARIA states and keyboard events, making them inaccessible to screen readers and difficult to use via keyboard navigation.
📸 **Before/After:** The component now visually highlights the focused items properly using `focus-visible` styles and can be closed natively via the `Escape` key.
♿ **Accessibility:**
- Added `aria-haspopup="true"` and `aria-controls` to the trigger button.
- Added `role="menu"` to the list container.
- Added `role="menuitem"` to each language option button.
- Implemented `Escape` key `keydown` listener to intuitively close the dropdown without losing focus state.
- Enhanced keyboard focus indication using Tailwind's `focus-visible` utilities.

---
*PR created automatically by Jules for task [18358014352677186258](https://jules.google.com/task/18358014352677186258) started by @gokaiorg*