### PR TITLE
🎨 Palette: Improve LanguageSwitcher accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,8 @@
 
 **Learning:** The `MiniSlider` component is frequently nested within `Link` components (e.g., in product lists), creating invalid HTML and accessibility issues because it renders interactive `<button>` elements for slide indicators.
 **Action:** When using `MiniSlider` inside a `Link`, always pass `interactive={false}` to render the indicators as non-interactive `<span>` elements, preventing nested interactive controls while maintaining visual feedback.
+
+## 2025-05-28 - Dropdown Escape Key Escape Pattern
+
+**Learning:** Dropdown elements like `LanguageSwitcher.tsx` need to specifically listen for the `Escape` key inside an effect, and then intelligently return focus back to the dropdown toggle button so keyboard users don't lose their place on the page. Returning focus correctly provides a massive UX win for accessibility.
+**Action:** When implementing or updating custom dropdown menus, always attach an `Escape` key listener on the document (with cleanup) to close the dropdown, and try to restore focus back to the toggle element.

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -38,9 +38,25 @@ export default function LanguageSwitcher() {
         setIsOpen(false);
       }
     }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape" && isOpen) {
+        setIsOpen(false);
+        // Return focus to the toggle button if possible
+        if (dropdownRef.current) {
+          const button = dropdownRef.current.querySelector('button');
+          if (button) button.focus();
+        }
+      }
+    }
+
     document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
 
   const handleLanguageChange = (langCode: string) => {
     setIsOpen(false);
@@ -78,18 +94,24 @@ export default function LanguageSwitcher() {
         className="flex items-center justify-center p-2 hover:bg-white/10 transition-colors text-white hover:text-[#13DE00] cursor-pointer"
         aria-label="Select language"
         aria-expanded={isOpen}
+        aria-haspopup="true"
+        aria-controls="language-menu"
       >
         <Globe size={20} />
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 mt-2 w-32 bg-black border border-[#13DE00] shadow-lg overflow-hidden z-50 animate-in fade-in zoom-in-95 duration-200">
-          <ul className="py-1">
+        <div
+          id="language-menu"
+          className="absolute right-0 mt-2 w-32 bg-black border border-[#13DE00] shadow-lg overflow-hidden z-50 animate-in fade-in zoom-in-95 duration-200"
+        >
+          <ul className="py-1" role="menu" aria-label="Language options">
             {languages.map((lang) => (
-              <li key={lang.code}>
+              <li key={lang.code} role="presentation">
                 <button
+                  role="menuitem"
                   onClick={() => handleLanguageChange(lang.code)}
-                  className={`w-full text-left px-4 py-2 text-xs font-medium flex items-center space-x-2 hover:bg-[#13DE00]/20 transition-colors cursor-pointer
+                  className={`w-full text-left px-4 py-2 text-xs font-medium flex items-center space-x-2 hover:bg-[#13DE00]/20 transition-colors cursor-pointer focus-visible:outline-none focus-visible:bg-[#13DE00]/20
                     ${currentLang.code === lang.code ? "text-[#13DE00] bg-[#13DE00]/10" : "text-white"}
                   `}
                 >


### PR DESCRIPTION
This PR improves the keyboard and screen reader accessibility for the `LanguageSwitcher` component. It adds standard WAI-ARIA roles (`menu`, `menuitem`, `presentation`) to properly structure the dropdown content. It connects the toggle button and the dropdown using `aria-controls`, and adds `aria-haspopup`. Lastly, it introduces an `Escape` key listener that safely closes the dropdown and returns focus to the toggle button, significantly enhancing the keyboard user experience.

---
*PR created automatically by Jules for task [2901307499235459594](https://jules.google.com/task/2901307499235459594) started by @gokaiorg*