### PR TITLE
🛡️ Sentinel: [MEDIUM] Add input length limits

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -82,3 +82,8 @@
 **Prevention:**
 1. Avoid `JSON.stringify` inside `dangerouslySetInnerHTML`.
 2. Use the provided `toJsonLd` utility helper function which properly escapes `<` to `\u003c`.
+## 2025-02-27 - Missing input length limits
+
+**Vulnerability:** Multiple user input fields across the application (Contact Form, Bag Messaging, Chat Window, Strain Search) lacked `maxLength` constraints. This could potentially allow excessively large payloads to be submitted or manipulated on the client side, leading to Denial of Service (DoS) risks or unintended application behavior.
+**Learning:** Client-side input validation is a crucial layer of defense-in-depth. While server-side validation is mandatory, adding basic constraints like `maxLength` on the frontend prevents unnecessary processing of oversized inputs and improves the application's resilience.
+**Prevention:** Always define reasonable `maxLength` limits on `<input>` and `<textarea>` elements based on the expected data (e.g., 100 for names, 255 for emails, 1000/2000 for messages).

--- a/src/app/[lang]/(products)/strains/StrainsClient.tsx
+++ b/src/app/[lang]/(products)/strains/StrainsClient.tsx
@@ -64,6 +64,7 @@ export default function StrainsClient() {
             placeholder="Search strains by name..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
+            maxLength={100}
             className="w-full px-4 py-2 bg-black/30 border border-[#13DE00]/30 text-white placeholder-gray-400 focus:outline-none focus:border-[#13DE00]/60 focus:bg-black/40"
           />
         </div>

--- a/src/components/BagMessaging.tsx
+++ b/src/components/BagMessaging.tsx
@@ -189,6 +189,7 @@ const AddressAutocomplete = ({
           type="text"
           value={locationName}
           onChange={handleInputChange}
+          maxLength={255}
           placeholder="e.g. 123 Rawai Beach Road"
           className="w-full p-2 border-2 border-red-500 bg-black text-white focus:ring-2 focus:ring-red-500 focus:border-transparent mt-1"
           required
@@ -207,6 +208,7 @@ const AddressAutocomplete = ({
           type="text"
           value={locationName}
           onChange={handleInputChange}
+          maxLength={255}
           placeholder="e.g. 123 Rawai Beach Road"
           className="w-full p-2 border-2 border-[#13DE00] bg-black text-white focus:ring-2 focus:ring-[#13DE00] focus:border-transparent mt-1"
           required
@@ -236,6 +238,7 @@ const AddressAutocomplete = ({
         type="text"
         value={locationName}
         onChange={handleInputChange}
+        maxLength={255}
         placeholder="Search your address (Thailand only)"
         className="w-full p-2 border-2 border-[#13DE00] bg-black text-white focus:ring-2 focus:ring-[#13DE00] focus:border-transparent mt-1"
         required
@@ -381,6 +384,7 @@ const BagMessaging = ({ items, total, onClose }: BagMessagingProps) => {
                 id="name"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
+                maxLength={100}
                 className="w-full p-2 border-2 border-[#13DE00] bg-black text-white focus:ring-2 focus:ring-[#13DE00] focus:border-transparent"
                 required
               />

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -293,6 +293,7 @@ export default function ChatWindow({
             type="text"
             value={input}
             onChange={(e) => setInput(e.target.value)}
+            maxLength={1000}
             placeholder="Type your message..."
             aria-label="Type your message"
             className="w-full flex-1 bg-[#13DE00]/13 text-white text-sm px-3 py-2 focus:outline-none focus:border-2 focus:border-[#13DE00]"

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -113,6 +113,7 @@ export default function ContactForm() {
               name="name"
               autoComplete="name"
               required
+              maxLength={100}
               value={formData.name}
               onChange={handleChange}
               className="w-full bg-black border-2 border-[#13DE00]/50 focus:border-[#13DE00] text-white p-3 outline-none transition-colors font-mono"
@@ -136,6 +137,7 @@ export default function ContactForm() {
               name="email"
               autoComplete="email"
               required
+              maxLength={255}
               value={formData.email}
               onChange={handleChange}
               className="w-full bg-black border-2 border-[#13DE00]/50 focus:border-[#13DE00] text-white p-3 outline-none transition-colors font-mono"
@@ -157,6 +159,7 @@ export default function ContactForm() {
               id="message"
               name="message"
               required
+              maxLength={2000}
               rows={5}
               value={formData.message}
               onChange={handleChange}


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add input length limits

🚨 Severity: MEDIUM
💡 Vulnerability: Multiple user input fields (Contact Form, Bag Messaging, Chat Window, Strain Search) lacked `maxLength` constraints, exposing the app to potential excessively large payloads.
🎯 Impact: Attackers or users could submit massive inputs that degrade client-side performance or bypass intended data length constraints.
🔧 Fix: Added reasonable `maxLength` attributes to all identified `<input>` and `<textarea>` elements across `StrainsClient`, `BagMessaging`, `ChatWindow`, and `ContactForm`.
✅ Verification: Ensure the input fields restrict typing beyond their set limits.

---
*PR created automatically by Jules for task [9996985245815113883](https://jules.google.com/task/9996985245815113883) started by @gokaiorg*