### PR TITLE
🎨 Palette: Improve LanguageSwitcher accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,8 @@
 
 **Learning:** The `MiniSlider` component is frequently nested within `Link` components (e.g., in product lists), creating invalid HTML and accessibility issues because it renders interactive `<button>` elements for slide indicators.
 **Action:** When using `MiniSlider` inside a `Link`, always pass `interactive={false}` to render the indicators as non-interactive `<span>` elements, preventing nested interactive controls while maintaining visual feedback.
+
+## $(date +%Y-%m-%d) - Language Switcher Accessibility
+
+**Learning:** Custom dropdown components like `LanguageSwitcher` built without UI primitives must implement ARIA attributes (`role="menu"`, `role="menuitem"`, `aria-haspopup`, `aria-controls`, `aria-expanded`) and an `Escape` key event listener for proper keyboard accessibility.
+**Action:** When implementing custom interactive elements, always consider screen reader roles and keyboard navigation (e.g., closing modals/dropdowns with Escape, focus states via `focus-visible`).

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -38,8 +38,19 @@ export default function LanguageSwitcher() {
         setIsOpen(false);
       }
     }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    }
+
     document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
   }, []);
 
   const handleLanguageChange = (langCode: string) => {
@@ -75,23 +86,26 @@ export default function LanguageSwitcher() {
     <div className="relative" ref={dropdownRef}>
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center justify-center p-2 hover:bg-white/10 transition-colors text-white hover:text-[#13DE00] cursor-pointer"
+        className="flex items-center justify-center p-2 hover:bg-white/10 transition-colors text-white hover:text-[#13DE00] cursor-pointer focus-visible:ring-2 focus-visible:ring-[#13DE00] focus-visible:outline-none"
         aria-label="Select language"
         aria-expanded={isOpen}
+        aria-haspopup="true"
+        aria-controls="language-menu"
       >
         <Globe size={20} />
       </button>
 
       {isOpen && (
         <div className="absolute right-0 mt-2 w-32 bg-black border border-[#13DE00] shadow-lg overflow-hidden z-50 animate-in fade-in zoom-in-95 duration-200">
-          <ul className="py-1">
+          <ul className="py-1" role="menu" id="language-menu">
             {languages.map((lang) => (
               <li key={lang.code}>
                 <button
                   onClick={() => handleLanguageChange(lang.code)}
-                  className={`w-full text-left px-4 py-2 text-xs font-medium flex items-center space-x-2 hover:bg-[#13DE00]/20 transition-colors cursor-pointer
+                  className={`w-full text-left px-4 py-2 text-xs font-medium flex items-center space-x-2 hover:bg-[#13DE00]/20 focus-visible:bg-[#13DE00]/20 focus-visible:outline-none transition-colors cursor-pointer
                     ${currentLang.code === lang.code ? "text-[#13DE00] bg-[#13DE00]/10" : "text-white"}
                   `}
+                  role="menuitem"
                 >
                   <span>{lang.label}</span>
                 </button>


### PR DESCRIPTION
🎨 Palette: Improve LanguageSwitcher accessibility

💡 What:
- Added `aria-haspopup`, `aria-expanded`, and `aria-controls` to the trigger button.
- Added `role="menu"` to the dropdown list.
- Added `role="menuitem"` to the language options.
- Implemented an `Escape` key event listener to allow keyboard users to close the dropdown.
- Added `focus-visible:ring` and `focus-visible:bg` utility classes to visually indicate focus for keyboard users without affecting mouse users.

🎯 Why:
Custom dropdowns built from scratch often lack inherent accessibility features. These changes ensure the `LanguageSwitcher` can be navigated by keyboard-only users and announced correctly by screen readers.

📸 Before/After:
No visual changes for mouse users. Keyboard users will now see a clear green focus ring when tabbing into the language button and language options.

♿ Accessibility:
- Keyboard Navigation (Escape key to close, visible focus states)
- Screen Reader Support (Roles and ARIA states)

---
*PR created automatically by Jules for task [16887780596767250217](https://jules.google.com/task/16887780596767250217) started by @gokaiorg*