### PR TITLE
🎨 Palette: Improve LanguageSwitcher accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,8 @@
 
 **Learning:** The `MiniSlider` component is frequently nested within `Link` components (e.g., in product lists), creating invalid HTML and accessibility issues because it renders interactive `<button>` elements for slide indicators.
 **Action:** When using `MiniSlider` inside a `Link`, always pass `interactive={false}` to render the indicators as non-interactive `<span>` elements, preventing nested interactive controls while maintaining visual feedback.
+
+## 2025-05-27 - Custom Dropdown Accessibility (LanguageSwitcher)
+
+**Learning:** When building custom dropdown components (like `LanguageSwitcher.tsx`), ARIA attributes must bridge the trigger button (`aria-haspopup`, `aria-controls`, `aria-expanded`) to the dropdown wrapper (`role="menu"`, `id`). Internal lists (`<ul>`, `<li>`) must have `role="none"` to reset their default semantics, while the actionable items must have `role="menuitem"`. Additionally, keyboard navigation (specifically closing on `Escape`) is crucial. A simple `mousedown` listener is insufficient.
+**Action:** When implementing custom dropdowns, always implement the complete ARIA menu pattern and an `Escape` key event listener. Ensure the keydown listener uses the correct dependencies (e.g., `isOpen`) to avoid stale closures if bound inside a `useEffect`.

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -38,9 +38,20 @@ export default function LanguageSwitcher() {
         setIsOpen(false);
       }
     }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape" && isOpen) {
+        setIsOpen(false);
+      }
+    }
+
     document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
 
   const handleLanguageChange = (langCode: string) => {
     setIsOpen(false);
@@ -78,17 +89,25 @@ export default function LanguageSwitcher() {
         className="flex items-center justify-center p-2 hover:bg-white/10 transition-colors text-white hover:text-[#13DE00] cursor-pointer"
         aria-label="Select language"
         aria-expanded={isOpen}
+        aria-haspopup="true"
+        aria-controls="language-menu"
       >
         <Globe size={20} />
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 mt-2 w-32 bg-black border border-[#13DE00] shadow-lg overflow-hidden z-50 animate-in fade-in zoom-in-95 duration-200">
-          <ul className="py-1">
+        <div
+          id="language-menu"
+          role="menu"
+          aria-label="Language options"
+          className="absolute right-0 mt-2 w-32 bg-black border border-[#13DE00] shadow-lg overflow-hidden z-50 animate-in fade-in zoom-in-95 duration-200"
+        >
+          <ul className="py-1" role="none">
             {languages.map((lang) => (
-              <li key={lang.code}>
+              <li key={lang.code} role="none">
                 <button
                   onClick={() => handleLanguageChange(lang.code)}
+                  role="menuitem"
                   className={`w-full text-left px-4 py-2 text-xs font-medium flex items-center space-x-2 hover:bg-[#13DE00]/20 transition-colors cursor-pointer
                     ${currentLang.code === lang.code ? "text-[#13DE00] bg-[#13DE00]/10" : "text-white"}
                   `}


### PR DESCRIPTION
Added necessary ARIA roles (`role="menu"`, `role="menuitem"`, `role="none"`) and properties (`aria-haspopup`, `aria-controls`) to the LanguageSwitcher dropdown. Added an `Escape` key listener to allow keyboard users to dismiss the dropdown.

---
*PR created automatically by Jules for task [6357124420164978994](https://jules.google.com/task/6357124420164978994) started by @gokaiorg*