### PR TITLE
🎨 Palette: [UX improvement] LanguageSwitcher Keyboard Accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,8 @@
 
 **Learning:** The `MiniSlider` component is frequently nested within `Link` components (e.g., in product lists), creating invalid HTML and accessibility issues because it renders interactive `<button>` elements for slide indicators.
 **Action:** When using `MiniSlider` inside a `Link`, always pass `interactive={false}` to render the indicators as non-interactive `<span>` elements, preventing nested interactive controls while maintaining visual feedback.
+
+## 2025-05-27 - Custom Dropdown Keyboard Management
+
+**Learning:** Dropdowns created with native HTML/React (like `LanguageSwitcher`) require explicit focus management. When closing via `Escape` key, it's essential to return focus to the trigger button so keyboard users do not lose their place in the DOM structure.
+**Action:** Whenever implementing custom dropdowns or modals, always ensure `Escape` closes the element AND restores focus to the invoking element. Additionally, verify `focus-visible` states are clearly defined for all interactive child items.

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -38,9 +38,25 @@ export default function LanguageSwitcher() {
         setIsOpen(false);
       }
     }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape" && isOpen) {
+        setIsOpen(false);
+        // Focus the toggle button when closing with Escape
+        const toggleButton = dropdownRef.current?.querySelector("button");
+        if (toggleButton) {
+          toggleButton.focus();
+        }
+      }
+    }
+
     document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
 
   const handleLanguageChange = (langCode: string) => {
     setIsOpen(false);
@@ -75,23 +91,31 @@ export default function LanguageSwitcher() {
     <div className="relative" ref={dropdownRef}>
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center justify-center p-2 hover:bg-white/10 transition-colors text-white hover:text-[#13DE00] cursor-pointer"
+        className="flex items-center justify-center p-2 hover:bg-white/10 transition-colors text-white hover:text-[#13DE00] cursor-pointer focus-visible:ring-2 focus-visible:ring-[#13DE00] focus-visible:outline-none"
         aria-label="Select language"
         aria-expanded={isOpen}
+        aria-haspopup="true"
+        aria-controls="language-menu"
       >
         <Globe size={20} />
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 mt-2 w-32 bg-black border border-[#13DE00] shadow-lg overflow-hidden z-50 animate-in fade-in zoom-in-95 duration-200">
+        <div
+          id="language-menu"
+          className="absolute right-0 mt-2 w-32 bg-black border border-[#13DE00] shadow-lg overflow-hidden z-50 animate-in fade-in zoom-in-95 duration-200"
+          role="menu"
+          aria-label="Language options"
+        >
           <ul className="py-1">
             {languages.map((lang) => (
-              <li key={lang.code}>
+              <li key={lang.code} role="none">
                 <button
                   onClick={() => handleLanguageChange(lang.code)}
-                  className={`w-full text-left px-4 py-2 text-xs font-medium flex items-center space-x-2 hover:bg-[#13DE00]/20 transition-colors cursor-pointer
+                  className={`w-full text-left px-4 py-2 text-xs font-medium flex items-center space-x-2 hover:bg-[#13DE00]/20 transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-[#13DE00] focus-visible:outline-none focus-visible:-outline-offset-2
                     ${currentLang.code === lang.code ? "text-[#13DE00] bg-[#13DE00]/10" : "text-white"}
                   `}
+                  role="menuitem"
                 >
                   <span>{lang.label}</span>
                 </button>


### PR DESCRIPTION
💡 **What:** Added comprehensive keyboard accessibility and ARIA roles to the `LanguageSwitcher` dropdown.
🎯 **Why:** Custom dropdowns need explicit keyboard management (like Escape to close) and clear focus states so screen reader and keyboard-only users can navigate them effectively.
♿ **Accessibility:**
- Added `Escape` key event listener to close the menu.
- Returns focus to the trigger button when closed via `Escape`.
- Added `role="menu"` to the container and `role="menuitem"` to the buttons.
- Added explicit `focus-visible:ring-2 focus-visible:ring-[#13DE00]` styles for clear focus indication.

---
*PR created automatically by Jules for task [11925443929549612267](https://jules.google.com/task/11925443929549612267) started by @gokaiorg*