### PR TITLE
🎨 Palette: Accessible keyboard navigation for custom dropdowns

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,8 @@
 
 **Learning:** The `MiniSlider` component is frequently nested within `Link` components (e.g., in product lists), creating invalid HTML and accessibility issues because it renders interactive `<button>` elements for slide indicators.
 **Action:** When using `MiniSlider` inside a `Link`, always pass `interactive={false}` to render the indicators as non-interactive `<span>` elements, preventing nested interactive controls while maintaining visual feedback.
+
+## 2025-05-28 - Custom Dropdown Keyboard Navigation
+
+**Learning:** Custom dropdown components like `LanguageSwitcher` and `NavBurger` lack native keyboard navigation. Without explicitly adding an `Escape` key listener to close the dropdown and returning focus to the trigger element (`triggerRef.current?.focus()`), keyboard users are trapped or lose their place in the DOM when navigating away.
+**Action:** When creating custom dropdowns or popovers, always include an `Escape` key handler that sets `isOpen(false)` and restores focus to the trigger button, in addition to standard `role="menu"` and `role="menuitem"` ARIA attributes.

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -23,6 +23,7 @@ export default function LanguageSwitcher() {
   const [isOpen, setIsOpen] = useState(false);
   const { showLoader } = useLoader();
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   // Determine current language from URL
   const currentLangCode = pathname.startsWith("/fr") ? "fr" : "en";
@@ -38,9 +39,21 @@ export default function LanguageSwitcher() {
         setIsOpen(false);
       }
     }
+
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === "Escape" && isOpen) {
+        setIsOpen(false);
+        triggerRef.current?.focus();
+      }
+    }
+
     document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [isOpen]);
 
   const handleLanguageChange = (langCode: string) => {
     setIsOpen(false);
@@ -74,22 +87,31 @@ export default function LanguageSwitcher() {
   return (
     <div className="relative" ref={dropdownRef}>
       <button
+        ref={triggerRef}
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center justify-center p-2 hover:bg-white/10 transition-colors text-white hover:text-[#13DE00] cursor-pointer"
+        className="flex items-center justify-center p-2 hover:bg-white/10 transition-colors text-white hover:text-[#13DE00] cursor-pointer focus-visible:ring-2 focus-visible:ring-[#13DE00] focus-visible:outline-none focus-visible:rounded"
         aria-label="Select language"
         aria-expanded={isOpen}
+        aria-haspopup="menu"
+        aria-controls="language-menu"
       >
         <Globe size={20} />
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 mt-2 w-32 bg-black border border-[#13DE00] shadow-lg overflow-hidden z-50 animate-in fade-in zoom-in-95 duration-200">
-          <ul className="py-1">
+        <div
+          id="language-menu"
+          className="absolute right-0 mt-2 w-32 bg-black border border-[#13DE00] shadow-lg overflow-hidden z-50 animate-in fade-in zoom-in-95 duration-200"
+          role="menu"
+          aria-label="Language options"
+        >
+          <ul className="py-1" role="none">
             {languages.map((lang) => (
-              <li key={lang.code}>
+              <li key={lang.code} role="none">
                 <button
+                  role="menuitem"
                   onClick={() => handleLanguageChange(lang.code)}
-                  className={`w-full text-left px-4 py-2 text-xs font-medium flex items-center space-x-2 hover:bg-[#13DE00]/20 transition-colors cursor-pointer
+                  className={`w-full text-left px-4 py-2 text-xs font-medium flex items-center space-x-2 hover:bg-[#13DE00]/20 transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#13DE00] focus-visible:outline-none
                     ${currentLang.code === lang.code ? "text-[#13DE00] bg-[#13DE00]/10" : "text-white"}
                   `}
                 >

--- a/src/components/NavBurger.tsx
+++ b/src/components/NavBurger.tsx
@@ -21,6 +21,7 @@ export default function NavBurger({
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const pathname = usePathname();
   const currentLang = locale || "en";
 
@@ -33,10 +34,19 @@ export default function NavBurger({
     };
     const handleScroll = () => setIsOpen(false);
 
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && isOpen) {
+        setIsOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+
     document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEscape);
     window.addEventListener("scroll", handleScroll, { passive: true });
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscape);
       window.removeEventListener("scroll", handleScroll);
     };
   }, [isOpen]);
@@ -44,21 +54,28 @@ export default function NavBurger({
   return (
     <div className="relative" ref={menuRef}>
       <button
+        ref={triggerRef}
         onClick={() => setIsOpen(!isOpen)}
-        className="hover:text-[#13DE00] transition-colors p-2 cursor-pointer"
+        className="hover:text-[#13DE00] transition-colors p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-[#13DE00] focus-visible:outline-none focus-visible:rounded"
         aria-label="Toggle menu"
+        aria-expanded={isOpen}
+        aria-haspopup="menu"
+        aria-controls="nav-burger-menu"
       >
         {isOpen ? <X size={24} /> : <Menu size={24} />}
       </button>
 
       {isOpen && (
         <ul
+          id="nav-burger-menu"
+          role="menu"
           className="fixed left-0 right-0 top-[60px] bg-black border-t border-b border-[#13DE00] shadow-lg py-1 z-50 md:absolute md:left-0 md:right-auto md:top-full md:mt-2 md:w-max md:border list-none m-0 p-0"
           aria-label="Mobile navigation menu"
         >
           {items.map((item) => (
-            <li key={item.path}>
+            <li key={item.path} role="none">
               <Link
+                role="menuitem"
                 href={getLocalizedUrl(item.path, currentLang)}
                 title={
                   currentLang === "fr" && item.label_fr
@@ -67,7 +84,7 @@ export default function NavBurger({
                       ? item.label_en
                       : item.label
                 }
-                className={`block px-4 py-2 text-sm hover:bg-[#13DE00]/13 hover:text-[#13DE00] whitespace-nowrap ${pathname.includes(item.path) ? "bg-[#13DE00]/13 text-[#13DE00]" : ""}`}
+                className={`block px-4 py-2 text-sm hover:bg-[#13DE00]/13 hover:text-[#13DE00] whitespace-nowrap focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#13DE00] focus-visible:outline-none ${pathname.includes(item.path) ? "bg-[#13DE00]/13 text-[#13DE00]" : ""}`}
                 onClick={() => setIsOpen(false)}
                 aria-current={pathname.includes(item.path) ? "page" : undefined}
               >
@@ -79,7 +96,7 @@ export default function NavBurger({
               </Link>
             </li>
           ))}
-          <li className="px-4 py-2 md:hidden">
+          <li className="px-4 py-2 md:hidden" role="none">
             <ConnectMenu />
           </li>
         </ul>


### PR DESCRIPTION
💡 What: Added ARIA roles and Escape key keyboard navigation to the `LanguageSwitcher` and `NavBurger` dropdown menus.
🎯 Why: Custom dropdowns built without primitives are inaccessible to keyboard and screen reader users. They could not be closed without losing focus or clicking outside.
♿ Accessibility:
- Added `role="menu"`, `role="menuitem"`, `aria-haspopup`, and `aria-expanded` for screen readers.
- Added an `Escape` key event listener that closes the dropdown and explicitly returns focus to the trigger button (`triggerRef.current?.focus()`).
- Added Tailwind `focus-visible` classes to provide a clear focus ring for keyboard navigation without affecting mouse users.

---
*PR created automatically by Jules for task [11338376859862927112](https://jules.google.com/task/11338376859862927112) started by @gokaiorg*