### PR TITLE
🎨 Palette: Improve custom dropdown accessibility (LanguageSwitcher & NavBurger)

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,8 @@
 
 **Learning:** The `MiniSlider` component is frequently nested within `Link` components (e.g., in product lists), creating invalid HTML and accessibility issues because it renders interactive `<button>` elements for slide indicators.
 **Action:** When using `MiniSlider` inside a `Link`, always pass `interactive={false}` to render the indicators as non-interactive `<span>` elements, preventing nested interactive controls while maintaining visual feedback.
+
+## 2025-05-28 - Custom Dropdown Accessibility (LanguageSwitcher & NavBurger)
+
+**Learning:** When building custom dropdown components without standard UI primitives, users relying on keyboard navigation or screen readers are often left behind if native ARIA roles and keyboard handlers are missing. It is crucial to add `aria-expanded`, `aria-haspopup`, and `aria-controls` on the toggle button, and explicitly structure the dropdown content using `role="menu"` on the container, `role="none"` on list items, and `role="menuitem"` on interactive elements. Furthermore, implementing an `Escape` key listener that not only closes the dropdown but also restores focus to the trigger element is necessary to prevent focus loss and maintain navigation flow.
+**Action:** Always implement a complete set of ARIA attributes and an `Escape` key focus-restoration handler when designing custom dropdowns, and ensure visual focus states (`focus-visible:ring-2`) are explicitly defined.

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -23,6 +23,7 @@ export default function LanguageSwitcher() {
   const [isOpen, setIsOpen] = useState(false);
   const { showLoader } = useLoader();
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   // Determine current language from URL
   const currentLangCode = pathname.startsWith("/fr") ? "fr" : "en";
@@ -38,9 +39,22 @@ export default function LanguageSwitcher() {
         setIsOpen(false);
       }
     }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (isOpen && event.key === "Escape") {
+        setIsOpen(false);
+        triggerRef.current?.focus();
+      }
+    }
+
     document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
 
   const handleLanguageChange = (langCode: string) => {
     setIsOpen(false);
@@ -74,24 +88,32 @@ export default function LanguageSwitcher() {
   return (
     <div className="relative" ref={dropdownRef}>
       <button
+        ref={triggerRef}
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center justify-center p-2 hover:bg-white/10 transition-colors text-white hover:text-[#13DE00] cursor-pointer"
+        className="flex items-center justify-center p-2 hover:bg-white/10 transition-colors text-white hover:text-[#13DE00] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#13DE00] focus-visible:ring-offset-2 focus-visible:ring-offset-black rounded-sm"
         aria-label="Select language"
         aria-expanded={isOpen}
+        aria-haspopup="true"
+        aria-controls="language-menu"
       >
         <Globe size={20} />
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 mt-2 w-32 bg-black border border-[#13DE00] shadow-lg overflow-hidden z-50 animate-in fade-in zoom-in-95 duration-200">
-          <ul className="py-1">
+        <div
+          id="language-menu"
+          className="absolute right-0 mt-2 w-32 bg-black border border-[#13DE00] shadow-lg overflow-hidden z-50 animate-in fade-in zoom-in-95 duration-200"
+          role="menu"
+        >
+          <ul className="py-1" role="none">
             {languages.map((lang) => (
-              <li key={lang.code}>
+              <li key={lang.code} role="none">
                 <button
                   onClick={() => handleLanguageChange(lang.code)}
-                  className={`w-full text-left px-4 py-2 text-xs font-medium flex items-center space-x-2 hover:bg-[#13DE00]/20 transition-colors cursor-pointer
+                  className={`w-full text-left px-4 py-2 text-xs font-medium flex items-center space-x-2 hover:bg-[#13DE00]/20 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#13DE00] focus-visible:ring-inset
                     ${currentLang.code === lang.code ? "text-[#13DE00] bg-[#13DE00]/10" : "text-white"}
                   `}
+                  role="menuitem"
                 >
                   <span>{lang.label}</span>
                 </button>

--- a/src/components/NavBurger.tsx
+++ b/src/components/NavBurger.tsx
@@ -21,6 +21,7 @@ export default function NavBurger({
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const pathname = usePathname();
   const currentLang = locale || "en";
 
@@ -33,10 +34,19 @@ export default function NavBurger({
     };
     const handleScroll = () => setIsOpen(false);
 
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (isOpen && event.key === "Escape") {
+        setIsOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+
     document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleKeyDown);
     window.addEventListener("scroll", handleScroll, { passive: true });
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
       window.removeEventListener("scroll", handleScroll);
     };
   }, [isOpen]);
@@ -44,21 +54,28 @@ export default function NavBurger({
   return (
     <div className="relative" ref={menuRef}>
       <button
+        ref={triggerRef}
         onClick={() => setIsOpen(!isOpen)}
-        className="hover:text-[#13DE00] transition-colors p-2 cursor-pointer"
+        className="hover:text-[#13DE00] transition-colors p-2 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#13DE00] focus-visible:ring-offset-2 focus-visible:ring-offset-black rounded-sm"
         aria-label="Toggle menu"
+        aria-expanded={isOpen}
+        aria-haspopup="true"
+        aria-controls="mobile-nav-menu"
       >
         {isOpen ? <X size={24} /> : <Menu size={24} />}
       </button>
 
       {isOpen && (
         <ul
+          id="mobile-nav-menu"
+          role="menu"
           className="fixed left-0 right-0 top-[60px] bg-black border-t border-b border-[#13DE00] shadow-lg py-1 z-50 md:absolute md:left-0 md:right-auto md:top-full md:mt-2 md:w-max md:border list-none m-0 p-0"
           aria-label="Mobile navigation menu"
         >
           {items.map((item) => (
-            <li key={item.path}>
+            <li key={item.path} role="none">
               <Link
+                role="menuitem"
                 href={getLocalizedUrl(item.path, currentLang)}
                 title={
                   currentLang === "fr" && item.label_fr
@@ -67,7 +84,7 @@ export default function NavBurger({
                       ? item.label_en
                       : item.label
                 }
-                className={`block px-4 py-2 text-sm hover:bg-[#13DE00]/13 hover:text-[#13DE00] whitespace-nowrap ${pathname.includes(item.path) ? "bg-[#13DE00]/13 text-[#13DE00]" : ""}`}
+                className={`block px-4 py-2 text-sm hover:bg-[#13DE00]/13 hover:text-[#13DE00] whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#13DE00] focus-visible:ring-inset ${pathname.includes(item.path) ? "bg-[#13DE00]/13 text-[#13DE00]" : ""}`}
                 onClick={() => setIsOpen(false)}
                 aria-current={pathname.includes(item.path) ? "page" : undefined}
               >
@@ -79,7 +96,7 @@ export default function NavBurger({
               </Link>
             </li>
           ))}
-          <li className="px-4 py-2 md:hidden">
+          <li className="px-4 py-2 md:hidden" role="none">
             <ConnectMenu />
           </li>
         </ul>


### PR DESCRIPTION
This PR addresses custom dropdown accessibility for both `LanguageSwitcher` and `NavBurger`.

It implements:
- Full `role="menu"` ARIA tree logic (`role="none"` on structural `li` elements, `role="menuitem"` on interactive contents).
- Toggle-level ARIA states (`aria-expanded`, `aria-haspopup`, `aria-controls`).
- `Escape` key logic that safely ensures the dropdown is closed AND restores focus to the original triggering button, making it completely keyboard navigable.
- Adds `focus-visible` styles so that keyboard navigation is obvious and usable.

Also records these learnings in `.jules/palette.md`.

---
*PR created automatically by Jules for task [11480946477558295792](https://jules.google.com/task/11480946477558295792) started by @gokaiorg*