### PR TITLE
🎨 Palette: LanguageSwitcher Keyboard & Screen Reader Support

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,8 @@
 
 **Learning:** The `MiniSlider` component is frequently nested within `Link` components (e.g., in product lists), creating invalid HTML and accessibility issues because it renders interactive `<button>` elements for slide indicators.
 **Action:** When using `MiniSlider` inside a `Link`, always pass `interactive={false}` to render the indicators as non-interactive `<span>` elements, preventing nested interactive controls while maintaining visual feedback.
+
+## 2025-05-28 - Dropdown Keyboard Accessibility
+
+**Learning:** Custom dropdown components like `LanguageSwitcher` require explicit keyboard management. Beyond adding standard ARIA roles (`menu`, `menuitem`), implementing an `Escape` key listener to close the dropdown and returning focus to the trigger button is crucial for keyboard navigation. We must ensure the event listener only triggers when the menu is actually open.
+**Action:** When building custom dropdowns, always implement an `Escape` key listener that returns focus to the trigger element, and use `focus-visible` to ensure clear focus indicators for keyboard users.

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -29,6 +29,8 @@ export default function LanguageSwitcher() {
   const currentLang =
     languages.find((l) => l.code === currentLangCode) || languages[0];
 
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (
@@ -38,9 +40,21 @@ export default function LanguageSwitcher() {
         setIsOpen(false);
       }
     }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (isOpen && event.key === "Escape") {
+        setIsOpen(false);
+        buttonRef.current?.focus();
+      }
+    }
+
     document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
 
   const handleLanguageChange = (langCode: string) => {
     setIsOpen(false);
@@ -74,22 +88,26 @@ export default function LanguageSwitcher() {
   return (
     <div className="relative" ref={dropdownRef}>
       <button
+        ref={buttonRef}
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center justify-center p-2 hover:bg-white/10 transition-colors text-white hover:text-[#13DE00] cursor-pointer"
+        className="flex items-center justify-center p-2 hover:bg-white/10 transition-colors text-white hover:text-[#13DE00] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#13DE00]"
         aria-label="Select language"
         aria-expanded={isOpen}
+        aria-haspopup="menu"
+        aria-controls={isOpen ? "language-menu" : undefined}
       >
         <Globe size={20} />
       </button>
 
       {isOpen && (
         <div className="absolute right-0 mt-2 w-32 bg-black border border-[#13DE00] shadow-lg overflow-hidden z-50 animate-in fade-in zoom-in-95 duration-200">
-          <ul className="py-1">
+          <ul id="language-menu" role="menu" className="py-1">
             {languages.map((lang) => (
-              <li key={lang.code}>
+              <li key={lang.code} role="none">
                 <button
+                  role="menuitem"
                   onClick={() => handleLanguageChange(lang.code)}
-                  className={`w-full text-left px-4 py-2 text-xs font-medium flex items-center space-x-2 hover:bg-[#13DE00]/20 transition-colors cursor-pointer
+                  className={`w-full text-left px-4 py-2 text-xs font-medium flex items-center space-x-2 hover:bg-[#13DE00]/20 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#13DE00] focus-visible:ring-inset
                     ${currentLang.code === lang.code ? "text-[#13DE00] bg-[#13DE00]/10" : "text-white"}
                   `}
                 >


### PR DESCRIPTION
Added proper ARIA roles (menu, none, menuitem) and keyboard support (Escape key to close, returning focus) to the LanguageSwitcher component to make it fully accessible.

---
*PR created automatically by Jules for task [1557624784302854844](https://jules.google.com/task/1557624784302854844) started by @gokaiorg*