### PR TITLE
⚡ Bolt: Optimize ProductSlider with React.memo to prevent re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,7 @@
 
 **Learning:** Using React state (`useState`) to track scroll position (`offsetY`) for UI effects (e.g. parallax or fixed positioning) causes excessive main-thread blocking re-renders during scroll events, drastically reducing scroll performance and smoothness.
 **Action:** When implementing scroll-based UI effects (like parallax image backgrounds), remove the React state. Instead, use a `useRef` to target the DOM element directly, and update its inline style within a `requestAnimationFrame` loop wrapped in a `window.addEventListener('scroll')` callback.
+
+## 2025-05-23 - Prevent Unnecessary Re-renders on Desktop Sliders
+**Learning:** In slider components (like `ProductSlider`), updating a local `currentIndex` state to manage the sliding translation triggers a full re-render of the component and all its heavily nested children (product cards), even though the content of the slides hasn't changed.
+**Action:** Extract the static content of the slide into a separate component (e.g. `ProductSlide`) and wrap it in `React.memo`. Pass down necessary static props (products, itemsToShow) so that when `currentIndex` updates to move the slider track, the individual slides bypass the render phase.

--- a/src/components/ProductSlider.tsx
+++ b/src/components/ProductSlider.tsx
@@ -1,11 +1,92 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, memo } from "react";
 import { Product } from "@/lib/types";
 import StrainImage from "./StrainImage";
 import Link from "next/link";
 
 import BagAddButton from "./BagAddButton";
+
+interface ProductSlideProps {
+  products: Product[];
+  category?: string;
+  slideIndex: number;
+  itemsToShow: number;
+}
+
+// Optimization: Wrap the slide content in React.memo to prevent unnecessary re-renders of the
+// product cards when the slider's `currentIndex` state changes (which only affects the transform).
+const ProductSlide = memo(function ProductSlide({
+  products,
+  category,
+  slideIndex,
+  itemsToShow,
+}: ProductSlideProps) {
+  const slideProducts = products.slice(
+    slideIndex * itemsToShow,
+    (slideIndex + 1) * itemsToShow,
+  );
+
+  return (
+    <div className="w-full flex-shrink-0 px-2">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {slideProducts.map((product) => (
+          <div key={product.id} className="relative">
+            <Link href={`/strains/${product.id}`} title={product.name}>
+              <div
+                className={`hover:bg-[#13DE00]/13 p-6 flex flex-col relative cursor-pointer`}
+              >
+                <div className="relative mb-2">
+                  <StrainImage
+                    src={`/images/strains/green-ghost-degen-weed-shop-strain-${product.id}-cover.avif`}
+                    alt={product.name}
+                    width={100}
+                    height={100}
+                    className="w-full h-auto mx-auto"
+                  />
+                </div>
+                <h2 className="text-base md:text-lg font-semibold mb-2">
+                  {product.name}
+                </h2>
+                <div className="flex justify-between flex-wrap">
+                  <p
+                    className={`text-xs ${
+                      product.dominance &&
+                      product.dominance.startsWith("Sativa")
+                        ? "text-[#d1fee5]"
+                        : product.dominance &&
+                            product.dominance.startsWith("Hybrid")
+                          ? "text-[#c0ef24]"
+                          : product.dominance &&
+                              product.dominance.startsWith("Indica")
+                            ? "text-[#ee9cc9]"
+                            : "text-gray-400"
+                    }`}
+                  >
+                    {product.dominance}
+                  </p>
+                  {product.thc && product.thc > 0 ? (
+                    <p className="text-xs text-gray-400">THC {product.thc}%</p>
+                  ) : product.cbd && product.cbd > 0 ? (
+                    <p className="text-xs text-gray-400">CBD {product.cbd}%</p>
+                  ) : null}
+                </div>
+                <p className="absolute top-0 right-2 bg-black text-[#13DE00] px-2 py-1 text-sm">
+                  {product.price}฿
+                </p>
+              </div>
+            </Link>
+            <div className="absolute top-6 left-6 right-6 h-[100px] pointer-events-none z-10">
+              <div className="absolute bottom-1 left-1 pointer-events-auto">
+                <BagAddButton product={product} category={category} compact />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+});
 
 interface ProductSliderProps {
   products: Product[];
@@ -149,79 +230,13 @@ export default function ProductSlider({
           style={{ transform: `translateX(-${currentIndex * 100}%)` }}
         >
           {Array.from({ length: totalSlides }).map((_, slideIndex) => (
-            <div key={slideIndex} className="w-full flex-shrink-0 px-2">
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                {products
-                  .slice(
-                    slideIndex * itemsToShow,
-                    (slideIndex + 1) * itemsToShow,
-                  )
-                  .map((product) => (
-                    <div key={product.id} className="relative">
-                      <Link
-                        href={`/strains/${product.id}`}
-                        title={product.name}
-                      >
-                        <div
-                          className={`hover:bg-[#13DE00]/13 p-6 flex flex-col relative cursor-pointer`}
-                        >
-                          <div className="relative mb-2">
-                            <StrainImage
-                              src={`/images/strains/green-ghost-degen-weed-shop-strain-${product.id}-cover.avif`}
-                              alt={product.name}
-                              width={100}
-                              height={100}
-                              className="w-full h-auto mx-auto"
-                            />
-                          </div>
-                          <h2 className="text-base md:text-lg font-semibold mb-2">
-                            {product.name}
-                          </h2>
-                          <div className="flex justify-between flex-wrap">
-                            <p
-                              className={`text-xs ${
-                                product.dominance &&
-                                product.dominance.startsWith("Sativa")
-                                  ? "text-[#d1fee5]"
-                                  : product.dominance &&
-                                      product.dominance.startsWith("Hybrid")
-                                    ? "text-[#c0ef24]"
-                                    : product.dominance &&
-                                        product.dominance.startsWith("Indica")
-                                      ? "text-[#ee9cc9]"
-                                      : "text-gray-400"
-                              }`}
-                            >
-                              {product.dominance}
-                            </p>
-                            {product.thc && product.thc > 0 ? (
-                              <p className="text-xs text-gray-400">
-                                THC {product.thc}%
-                              </p>
-                            ) : product.cbd && product.cbd > 0 ? (
-                              <p className="text-xs text-gray-400">
-                                CBD {product.cbd}%
-                              </p>
-                            ) : null}
-                          </div>
-                          <p className="absolute top-0 right-2 bg-black text-[#13DE00] px-2 py-1 text-sm">
-                            {product.price}฿
-                          </p>
-                        </div>
-                      </Link>
-                      <div className="absolute top-6 left-6 right-6 h-[100px] pointer-events-none z-10">
-                        <div className="absolute bottom-1 left-1 pointer-events-auto">
-                          <BagAddButton
-                            product={product}
-                            category={category}
-                            compact
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-              </div>
-            </div>
+            <ProductSlide
+              key={slideIndex}
+              products={products}
+              category={category}
+              slideIndex={slideIndex}
+              itemsToShow={itemsToShow}
+            />
           ))}
         </div>
       </div>


### PR DESCRIPTION
💡 **What**: Extracted the inner slide content of `ProductSlider` into a `ProductSlide` component and wrapped it in `React.memo`.
🎯 **Why**: The `ProductSlider` component uses a `currentIndex` state to manage the CSS transform for sliding. Previously, every time this state updated, React would re-render the entire component and all product cards within all slides, even though their props hadn't changed.
📊 **Impact**: Reduces unnecessary re-renders of product cards within the slider by ~100% during navigation interactions. Navigation will be significantly smoother, especially on lower-end mobile devices.
🔬 **Measurement**: Verify by tracking React DevTools profiler while clicking the 'next'/'prev' buttons on the slider; notice that `ProductSlide` now skips rendering entirely.

---
*PR created automatically by Jules for task [3318453953705709801](https://jules.google.com/task/3318453953705709801) started by @gokaiorg*