### PR TITLE
⚡ Bolt: Optimize parallax scroll event to prevent main-thread blocking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,6 @@
 
 **Learning:** Using React state (`useState`) to track scroll position (`offsetY`) for UI effects (e.g. parallax or fixed positioning) causes excessive main-thread blocking re-renders during scroll events, drastically reducing scroll performance and smoothness.
 **Action:** When implementing scroll-based UI effects (like parallax image backgrounds), remove the React state. Instead, use a `useRef` to target the DOM element directly, and update its inline style within a `requestAnimationFrame` loop wrapped in a `window.addEventListener('scroll')` callback.
+## 2026-06-21 - Parallax Scroll Main-Thread Blocking
+**Learning:** Parallax scroll event listeners that directly calculate layout (e.g. `getBoundingClientRect()`) and update the DOM synchronously on every scroll tick cause severe main-thread blocking and layout thrashing, significantly dropping scroll framerates.
+**Action:** Always throttle scroll-based UI updates using a `requestAnimationFrame` loop governed by a boolean `ticking` flag to ensure layout calculations and style updates happen at most once per frame.

--- a/src/components/BannerHero.tsx
+++ b/src/components/BannerHero.tsx
@@ -36,7 +36,12 @@ export default function BannerHero({
   }, []);
 
   useEffect(() => {
-    const handleScroll = () => {
+    // ⚡ Bolt: Throttled scroll event with requestAnimationFrame to prevent main-thread
+    // blocking and layout thrashing (getBoundingClientRect).
+    // Expected impact: smoother 60fps scrolling performance on mobile devices.
+    let ticking = false;
+
+    const updateParallax = () => {
       if (parallaxRef.current && bgRef.current) {
         const rect = parallaxRef.current.getBoundingClientRect();
 
@@ -46,6 +51,14 @@ export default function BannerHero({
           const offset = scrolled * 0.5;
           bgRef.current.style.transform = `translateY(${offset}px)`;
         }
+      }
+      ticking = false;
+    };
+
+    const handleScroll = () => {
+      if (!ticking) {
+        window.requestAnimationFrame(updateParallax);
+        ticking = true;
       }
     };
 


### PR DESCRIPTION
💡 What: Throttled the parallax scroll event listener in `BannerHero.tsx` using `requestAnimationFrame`.
🎯 Why: The previous implementation performed layout calculations (`getBoundingClientRect`) and DOM style updates synchronously on every fast-firing scroll event, which causes main-thread blocking and layout thrashing (jank).
📊 Impact: Considerably smoother scrolling performance (closer to 60fps), especially on mobile devices, due to eliminated layout thrashing.
🔬 Measurement: Verified the code prevents multiple synchronous layout calculations per frame using a `ticking` flag. The improvement can be observed via Chrome DevTools Performance tab by comparing layout shift times during scroll before and after the change.

---
*PR created automatically by Jules for task [6787593582639024180](https://jules.google.com/task/6787593582639024180) started by @gokaiorg*