### PR TITLE
⚡ Bolt: Memoize ProductSlide to prevent unnecessary re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,6 @@
 
 **Learning:** Using React state (`useState`) to track scroll position (`offsetY`) for UI effects (e.g. parallax or fixed positioning) causes excessive main-thread blocking re-renders during scroll events, drastically reducing scroll performance and smoothness.
 **Action:** When implementing scroll-based UI effects (like parallax image backgrounds), remove the React state. Instead, use a `useRef` to target the DOM element directly, and update its inline style within a `requestAnimationFrame` loop wrapped in a `window.addEventListener('scroll')` callback.
+## 2024-07-28 - [Memoizing Product Cards in Sliders]
+**Learning:** Carousel components like `ProductSlider.tsx` naturally have state changes for their translation offsets (e.g. `currentIndex`). Rendering nested complex items natively inside the mapping array forces all item DOM structures to re-render constantly.
+**Action:** Always extract individual slide items into their own memoized components (`React.memo`) to prevent re-renders when their own props (`product` object) haven't changed.

--- a/src/components/ProductSlider.tsx
+++ b/src/components/ProductSlider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, memo } from "react";
 import { Product } from "@/lib/types";
 import StrainImage from "./StrainImage";
 import Link from "next/link";
@@ -11,6 +11,68 @@ interface ProductSliderProps {
   products: Product[];
   category?: string;
 }
+
+// ⚡ Bolt: Memoized ProductSlide to prevent unnecessary re-renders of all product cards
+// when the parent ProductSlider's currentIndex state changes during navigation.
+const ProductSlide = memo(function ProductSlide({
+  product,
+  category,
+}: {
+  product: Product;
+  category: string;
+}) {
+  return (
+    <div className="relative">
+      <Link href={`/strains/${product.id}`} title={product.name}>
+        <div
+          className={`hover:bg-[#13DE00]/13 p-6 flex flex-col relative cursor-pointer`}
+        >
+          <div className="relative mb-2">
+            <StrainImage
+              src={`/images/strains/green-ghost-degen-weed-shop-strain-${product.id}-cover.avif`}
+              alt={product.name}
+              width={100}
+              height={100}
+              className="w-full h-auto mx-auto"
+            />
+          </div>
+          <h2 className="text-base md:text-lg font-semibold mb-2">
+            {product.name}
+          </h2>
+          <div className="flex justify-between flex-wrap">
+            <p
+              className={`text-xs ${
+                product.dominance && product.dominance.startsWith("Sativa")
+                  ? "text-[#d1fee5]"
+                  : product.dominance && product.dominance.startsWith("Hybrid")
+                    ? "text-[#c0ef24]"
+                    : product.dominance &&
+                        product.dominance.startsWith("Indica")
+                      ? "text-[#ee9cc9]"
+                      : "text-gray-400"
+              }`}
+            >
+              {product.dominance}
+            </p>
+            {product.thc && product.thc > 0 ? (
+              <p className="text-xs text-gray-400">THC {product.thc}%</p>
+            ) : product.cbd && product.cbd > 0 ? (
+              <p className="text-xs text-gray-400">CBD {product.cbd}%</p>
+            ) : null}
+          </div>
+          <p className="absolute top-0 right-2 bg-black text-[#13DE00] px-2 py-1 text-sm">
+            {product.price}฿
+          </p>
+        </div>
+      </Link>
+      <div className="absolute top-6 left-6 right-6 h-[100px] pointer-events-none z-10">
+        <div className="absolute bottom-1 left-1 pointer-events-auto">
+          <BagAddButton product={product} category={category} compact />
+        </div>
+      </div>
+    </div>
+  );
+});
 
 export default function ProductSlider({
   products,
@@ -157,68 +219,11 @@ export default function ProductSlider({
                     (slideIndex + 1) * itemsToShow,
                   )
                   .map((product) => (
-                    <div key={product.id} className="relative">
-                      <Link
-                        href={`/strains/${product.id}`}
-                        title={product.name}
-                      >
-                        <div
-                          className={`hover:bg-[#13DE00]/13 p-6 flex flex-col relative cursor-pointer`}
-                        >
-                          <div className="relative mb-2">
-                            <StrainImage
-                              src={`/images/strains/green-ghost-degen-weed-shop-strain-${product.id}-cover.avif`}
-                              alt={product.name}
-                              width={100}
-                              height={100}
-                              className="w-full h-auto mx-auto"
-                            />
-                          </div>
-                          <h2 className="text-base md:text-lg font-semibold mb-2">
-                            {product.name}
-                          </h2>
-                          <div className="flex justify-between flex-wrap">
-                            <p
-                              className={`text-xs ${
-                                product.dominance &&
-                                product.dominance.startsWith("Sativa")
-                                  ? "text-[#d1fee5]"
-                                  : product.dominance &&
-                                      product.dominance.startsWith("Hybrid")
-                                    ? "text-[#c0ef24]"
-                                    : product.dominance &&
-                                        product.dominance.startsWith("Indica")
-                                      ? "text-[#ee9cc9]"
-                                      : "text-gray-400"
-                              }`}
-                            >
-                              {product.dominance}
-                            </p>
-                            {product.thc && product.thc > 0 ? (
-                              <p className="text-xs text-gray-400">
-                                THC {product.thc}%
-                              </p>
-                            ) : product.cbd && product.cbd > 0 ? (
-                              <p className="text-xs text-gray-400">
-                                CBD {product.cbd}%
-                              </p>
-                            ) : null}
-                          </div>
-                          <p className="absolute top-0 right-2 bg-black text-[#13DE00] px-2 py-1 text-sm">
-                            {product.price}฿
-                          </p>
-                        </div>
-                      </Link>
-                      <div className="absolute top-6 left-6 right-6 h-[100px] pointer-events-none z-10">
-                        <div className="absolute bottom-1 left-1 pointer-events-auto">
-                          <BagAddButton
-                            product={product}
-                            category={category}
-                            compact
-                          />
-                        </div>
-                      </div>
-                    </div>
+                    <ProductSlide
+                      key={product.id}
+                      product={product}
+                      category={category}
+                    />
                   ))}
               </div>
             </div>


### PR DESCRIPTION
💡 What: Extracted the inline product card UI from `ProductSlider.tsx`'s `.map` function into a separate `ProductSlide` component and wrapped it in `React.memo()`.

🎯 Why: The `ProductSlider` component frequently updates its `currentIndex` state during navigation. Previously, this state change caused every product card (and all of its child components, images, and DOM nodes) to re-render, creating unnecessary work on the main thread.

📊 Impact: Reduces re-renders of the product cards by 100% during slider navigation. Cards now only re-render when their individual `product` props change.

🔬 Measurement: Verify by interacting with the slider using React DevTools Profiler. The product cards will show as skipping render because props did not change.

---
*PR created automatically by Jules for task [15642799776735027802](https://jules.google.com/task/15642799776735027802) started by @gokaiorg*